### PR TITLE
Add a project column to all tables

### DIFF
--- a/python/desc/pserv/Pserv.py
+++ b/python/desc/pserv/Pserv.py
@@ -135,7 +135,8 @@ class DbConnection(object):
                 raise RuntimeError(message)
 
 def create_csv_file_from_fits(fits_file, fits_hdunum, csv_file,
-                              column_mapping=None, scale_factors=None):
+                              column_mapping=None, scale_factors=None,
+                              add_ons=None):
     "Create a csv file from a FITS binary table."
     bintable = fits.open(fits_file)[fits_hdunum]
     if column_mapping is None:
@@ -144,8 +145,14 @@ def create_csv_file_from_fits(fits_file, fits_hdunum, csv_file,
     if scale_factors is None:
         scale_factors = {}
     with open(csv_file, 'w') as csv_output:
-        writer = csv.writer(csv_output, delimiter=',')
-        writer.writerow(list(column_mapping.keys()))
+        writer = csv.writer(csv_output, delimiter=',', lineterminator='\n')
+        colnames = list(column_mapping.keys())
+        add_on_values = []
+        if add_ons is not None:
+            for key, value in add_ons.items():
+                colnames.append(key)
+                add_on_values.append(value)
+        writer.writerow(colnames)
         nrows = bintable.header['NAXIS2']
         columns = []
         for colname in column_mapping.values():
@@ -159,4 +166,4 @@ def create_csv_file_from_fits(fits_file, fits_hdunum, csv_file,
             else: # Assume colname is a numeric constant.
                 columns.append([colname]*nrows)
         for row in zip(*tuple(columns)):
-            writer.writerow(row)
+            writer.writerow(list(row) + add_on_values)

--- a/python/desc/pserv/utils.py
+++ b/python/desc/pserv/utils.py
@@ -145,7 +145,7 @@ def ingest_Object_data(connection, catalog_file, project):
                    (objectId, parentObjectId, psRa, psDecl, project)
                    values (%i, %i, %17.9e, %17.9e, '%s')
                    on duplicate key update psRa=%17.9e, psDecl=%17.9e""" \
-            % (objectId, parent, ra_val, dec_val, ra_val, dec_val, project)
+            % (objectId, parent, ra_val, dec_val, project, ra_val, dec_val)
         connection.apply(query)
         nrows += 1
     print("!")

--- a/python/desc/pserv/utils.py
+++ b/python/desc/pserv/utils.py
@@ -38,11 +38,11 @@ def ingest_registry(connection, registry_file, project):
         query = """insert into CcdVisit set ccdVisitId=%(ccdVisitId)i,
                    visitId=%(visit)i, ccdName='%(ccd)s',
                    raftName='%(raft)s', filterName='%(filter_)s',
-                   obsStart='%(taiObs)s'
+                   obsStart='%(taiObs)s', project='%(project)s'
                    on duplicate key update
                    visitId=%(visit)i, ccdName='%(ccd)s',
                    raftName='%(raft)s', filterName='%(filter_)s',
-                   obsStart='%(taiObs)s', project='%(project)s'""" % locals()
+                   obsStart='%(taiObs)s'""" % locals()
         try:
             connection.apply(query)
         except Exception as eobj:
@@ -91,9 +91,9 @@ def ingest_calexp_info(connection, repo, project):
                                           afwMath.STDEVCLIP).getValue()
         query = """update CcdVisit set zeroPoint=%(zeroPoint)15.9e,
                    seeing=%(seeing)15.9e,
-                   skyBg=%(skyBg)15.9e, skyNoise=%(skyNoise)15.9e,
-                   project='%(project)s'
-                   where ccdVisitId=%(ccdVisitId)i""" % locals()
+                   skyBg=%(skyBg)15.9e, skyNoise=%(skyNoise)15.9e
+                   where ccdVisitId=%(ccdVisitId)i and
+                   project='%(project)s'""" % locals()
         connection.apply(query)
         nrows += 1
     print('!')

--- a/python/desc/pserv/utils.py
+++ b/python/desc/pserv/utils.py
@@ -17,10 +17,13 @@ def make_ccdVisitId(visit, raft, sensor):
     Return an integer that uniquely identifies a visit-raft-sensor
     combination.
     """
-    # @todo Include raft and sensor info into the return value.
-    return visit
+    # There are around 2.5 million visits in the 10 year survey, so 7
+    # digits should suffice for the visit part.  Prepend the RRSS
+    # combination to that and return as a long int.
+    ccdVisitId = long(raft[:3:2] + sensor[:3:2] + "%07i" % visit)
+    return ccdVisitId
 
-def ingest_registry(connection, registry_file):
+def ingest_registry(connection, registry_file, project):
     """
     Ingest some relevant data from a registry.sqlite3 file into
     the CcdVisit table.
@@ -39,14 +42,14 @@ def ingest_registry(connection, registry_file):
                    on duplicate key update
                    visitId=%(visit)i, ccdName='%(ccd)s',
                    raftName='%(raft)s', filterName='%(filter_)s',
-                   obsStart='%(taiObs)s'""" % locals()
+                   obsStart='%(taiObs)s', project='%(project)s'""" % locals()
         try:
             connection.apply(query)
         except Exception as eobj:
             print("query:", query)
             raise eobj
 
-def ingest_calexp_info(connection, repo):
+def ingest_calexp_info(connection, repo, project):
     """
     Extract information such as zeroPoint, seeing, sky background, sky
     noise, etc., from the calexp products and insert the values into
@@ -88,13 +91,15 @@ def ingest_calexp_info(connection, repo):
                                           afwMath.STDEVCLIP).getValue()
         query = """update CcdVisit set zeroPoint=%(zeroPoint)15.9e,
                    seeing=%(seeing)15.9e,
-                   skyBg=%(skyBg)15.9e, skyNoise=%(skyNoise)15.9e
+                   skyBg=%(skyBg)15.9e, skyNoise=%(skyNoise)15.9e,
+                   project='%(project)s'
                    where ccdVisitId=%(ccdVisitId)i""" % locals()
         connection.apply(query)
         nrows += 1
     print('!')
 
-def ingest_ForcedSource_data(connection, catalog_file, ccdVisitId, zeroPoint,
+def ingest_ForcedSource_data(connection, catalog_file, ccdVisitId,
+                             zeroPoint, project,
                              psFlux='base_PsfFlux_flux',
                              psFlux_Sigma='base_PsfFlux_fluxSigma',
                              flags=0, fits_hdunum=1, csv_file='temp.csv',
@@ -114,12 +119,13 @@ def ingest_ForcedSource_data(connection, catalog_file, ccdVisitId, zeroPoint,
                           (psFlux_Sigma, 1e9/zeroPoint)))
     create_csv_file_from_fits(catalog_file, fits_hdunum, csv_file,
                               column_mapping=column_mapping,
-                              scale_factors=scale_factors)
+                              scale_factors=scale_factors,
+                              add_ons=dict(project=project))
     connection.load_csv('ForcedSource', csv_file)
     if cleanup:
         os.remove(csv_file)
 
-def ingest_Object_data(connection, catalog_file):
+def ingest_Object_data(connection, catalog_file, project):
     "Ingest the reference catalog from the merged coadds."
     data = fits.open(catalog_file)[1].data
     nobjs = len(data['id'])
@@ -136,10 +142,10 @@ def ingest_Object_data(connection, catalog_file):
         ra_val = ra*180./np.pi
         dec_val = dec*180./np.pi
         query = """insert into Object
-                   (objectId, parentObjectId, psRa, psDecl)
-                   values (%i, %i, %17.9e, %17.9e)
+                   (objectId, parentObjectId, psRa, psDecl, project)
+                   values (%i, %i, %17.9e, %17.9e, '%s')
                    on duplicate key update psRa=%17.9e, psDecl=%17.9e""" \
-            % (objectId, parent, ra_val, dec_val, ra_val, dec_val)
+            % (objectId, parent, ra_val, dec_val, ra_val, dec_val, project)
         connection.apply(query)
         nrows += 1
     print("!")

--- a/python/desc/pserv/utils.py
+++ b/python/desc/pserv/utils.py
@@ -19,8 +19,8 @@ def make_ccdVisitId(visit, raft, sensor):
     """
     # There are around 2.5 million visits in the 10 year survey, so 7
     # digits should suffice for the visit part.  Prepend the RRSS
-    # combination to that and return as a long int.
-    ccdVisitId = long(raft[:3:2] + sensor[:3:2] + "%07i" % visit)
+    # combination to that and return as an int.
+    ccdVisitId = int(raft[:3:2] + sensor[:3:2] + "%07i" % visit)
     return ccdVisitId
 
 def ingest_registry(connection, registry_file, project):

--- a/sql/create_CcdVisit.sql
+++ b/sql/create_CcdVisit.sql
@@ -31,5 +31,6 @@ create table CcdVisit (
        skyBg FLOAT,
        skyNoise FLOAT,
        flags INTEGER,
-       primary key (ccdVisitId)
+       project CHAR(30),
+       primary key (ccdVisitId, project)
        )

--- a/sql/create_ForcedSource.sql
+++ b/sql/create_ForcedSource.sql
@@ -4,5 +4,6 @@ create table ForcedSource (
        psFlux FLOAT,
        psFlux_Sigma FLOAT,
        flags TINYINT,
-       primary key (objectId, ccdVisitID)
+       project CHAR(30),
+       primary key (objectId, ccdVisitID, project)
        )

--- a/sql/create_Object.sql
+++ b/sql/create_Object.sql
@@ -330,5 +330,6 @@ create table Object (
        extendedness FLOAT,
        FLAGS1 BIGINT,
        FLAGS2 BIGINT,
-       primary key (objectId)
+       project CHAR(30),
+       primary key (objectId, project)
        )

--- a/tests/test_Pserv.py
+++ b/tests/test_Pserv.py
@@ -57,10 +57,11 @@ class PservTestCase(unittest.TestCase):
         """
         self.connection = desc.pserv.DbConnection(**_db_info)
         self.test_table = 'my_test'
-        self.data = (('a', 1, 130., 3.1943029977e-24),
-                     ('b', 4, 1.4938229e-20, 4.408099891e10),
-                     ('c', 100, np.pi, np.pi),
-                     ('d', 3, 4.9039542e20, 9.487982348e30))
+        self.project = 'my project'
+        self.data = (('a', 1, 130., 3.1943029977e-24, self.project),
+                     ('b', 4, 1.4938229e-20, 4.408099891e10, self.project),
+                     ('c', 100, np.pi, np.pi, self.project),
+                     ('d', 3, 4.9039542e20, 9.487982348e30, self.project))
         self._create_test_table()
         # FITS/csv related set up:
         self.fits_file = 'my_test_data.fits'
@@ -85,7 +86,8 @@ class PservTestCase(unittest.TestCase):
         """
         self.connection.apply('drop table if exists %s;' % self.test_table)
         query = """create table %s (keywd char(1), int_value int,
-                   float_value float, double_value double);""" % self.test_table
+                   float_value float, double_value double,
+                   project char(30));""" % self.test_table
         self.connection.apply(query)
 
     def _fill_test_table(self):
@@ -93,7 +95,7 @@ class PservTestCase(unittest.TestCase):
         Fill the test db table with key/value pairs from self.data.
         """
         table_name = self.test_table
-        values = ','.join(["('%s', %i, %e, %e)" % row
+        values = ','.join(["('%s', %i, %e, %e, '%s')" % row
                            for row in self.data]) + ';'
         query = "insert into %(table_name)s values %(values)s" % locals()
         self.connection.apply(query)
@@ -102,7 +104,8 @@ class PservTestCase(unittest.TestCase):
         """
         Query for the test table contents.
         """
-        query = "select keywd, int_value, float_value from %s" % self.test_table
+        query = """select keywd, int_value, float_value, double_value,
+                   project from %s""" % self.test_table
         return self.connection.apply(
             query, cursorFunc=lambda curs: tuple(x for x in curs))
 
@@ -115,6 +118,7 @@ class PservTestCase(unittest.TestCase):
             fp1 = format_ % query_row[2]
             fp2 = format_ % ref_row[2]
             self.assertEqual(fp1, fp2)
+            self.assertEqual(query_row[4], self.project)
             #self.assertAlmostEqual(query_row[2], ref_row[2], places=places)
 
     def test_apply_cursorFunc(self):
@@ -157,7 +161,8 @@ class PservTestCase(unittest.TestCase):
                                           ('double_value', 'DOUBLE_VALUE')))
         desc.pserv.create_csv_file_from_fits(self.fits_file, fits_hdnum,
                                              csv_file,
-                                             column_mapping=column_mapping)
+                                             column_mapping=column_mapping,
+                                             add_ons=dict(project=self.project))
         return csv_file
 
     @staticmethod
@@ -170,7 +175,7 @@ class PservTestCase(unittest.TestCase):
                     # Skip the header line.
                     continue
                 csv_data.append((row[0], int(row[1]), float(row[2]),
-                                 np.float64(row[3])))
+                                 np.float64(row[3]), row[4]))
         return csv_data
 
     def test_create_csv_file_from_fits(self):
@@ -236,7 +241,8 @@ class PservTestCase(unittest.TestCase):
         desc.pserv.create_csv_file_from_fits(self.fits_file, fits_hdunum,
                                              csv_file,
                                              column_mapping=column_mapping,
-                                             scale_factors=scale_factors)
+                                             scale_factors=scale_factors,
+                                             add_ons=dict(project=self.project))
         csv_data = self._read_csv_file(csv_file)
         for csv_row, ref_row in zip(csv_data, self.data):
             self.assertEqual(csv_row[0], ref_row[0])

--- a/tests/test_Pserv.py
+++ b/tests/test_Pserv.py
@@ -265,7 +265,7 @@ class PservTestCase(unittest.TestCase):
         table_data = self._query_test_table()
         self._compare_to_ref_data(table_data)
 
-    def test_incorrect_cvs_mapping(self):
+    def test_incorrect_csv_mapping(self):
         """
         Test that an incorrect column mapping raises a RuntimeError.
         """


### PR DESCRIPTION
This will enable different projects to share the same set of Level 2 tables, even if objectIds, ccdVisitIds, etc., overlap.